### PR TITLE
REPO: Tämän hetkisen kappaleen korostus sivupalkissa ja sivupalkin siirtyminen kappaleen kohdalle

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -13,10 +13,10 @@
 .in-view {
   background-color: #edc949;
 
-  padding-left: 2em;
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  padding-right: 2em;
+  padding-left: 5%;
+  padding-top: 2%;
+  padding-bottom: 2%;
+  padding-right: 10%;
 
   border-radius: 0.5em;
 }
@@ -488,3 +488,4 @@ code span {
 @media (max-width: 767px) {
     .level1 { padding: 60px 10px; }
 }
+

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -4,12 +4,21 @@
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300;400;700&display=swap");
 @import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css");
 
-/* test */
-
 /* to-do */
 .todo {
     background-color: red;
     color:#eeeeee;
+}
+
+.in-view {
+  background-color: #edc949;
+
+  padding-left: 2em;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  padding-right: 2em;
+
+  border-radius: 0.5em;
 }
 
 /* Generics */

--- a/assets/js/nav-script.js
+++ b/assets/js/nav-script.js
@@ -4,3 +4,70 @@ function navToggle() {
   let hamburger = document.querySelector('.hamburger')
   hamburger.classList.toggle('is-active');
 }
+
+const sidebarLinks = document.querySelectorAll('.sidebar-nav a');
+const documentFileName = window.location.pathname.split('/').pop();
+
+var matchingLinks = [];
+
+sidebarLinks.forEach(function(link) {
+  var linkHref = link.getAttribute('href').split('#')[0];
+  var linkFileName = linkHref.split('/').pop();
+  if (linkFileName === documentFileName)
+    matchingLinks.push(link);
+
+});
+
+
+const headers = document.querySelectorAll(
+  "h1:not(.sidebar-nav h1), " +
+  "h2, " +
+  "h3"
+);
+
+
+// // Jump to to current document's title in the sidebar
+
+document.addEventListener('DOMContentLoaded', function() {
+  var pageTitle = document.title;
+
+  var targetLink = null;
+
+  matchingLinks.forEach(function(link) {
+    if (pageTitle.includes(link.textContent.trim())) 
+    {
+      targetLink = link;
+      return;
+    }
+  });
+
+  if (targetLink) {
+    targetLink.classList.add('in-view');
+    targetLink.scrollIntoView({
+      behavior: 'instant',
+      block: 'center'
+    });
+  }
+});
+
+// Highlight the header in the sidebar you're currently scrolling at in the main body
+
+window.addEventListener("scroll", () => {
+  headers.forEach((header) => {
+    const headerTop = header.offsetTop;
+    const headerHeight = header.clientHeight;
+
+    if (scrollY >= (headerTop - 100) - headerHeight)
+    {
+      current = header;
+    }
+
+    matchingLinks.forEach((link) => {
+      link.classList.remove("in-view");
+      if (link.textContent == current.textContent)
+      {
+        link.classList.add('in-view');
+      }
+    });
+  });
+});

--- a/assets/js/nav-script.js
+++ b/assets/js/nav-script.js
@@ -57,7 +57,7 @@ window.addEventListener("scroll", () => {
     const headerTop = header.offsetTop;
     const headerHeight = header.clientHeight;
 
-    if (scrollY >= (headerTop - 100) - headerHeight)
+    if (scrollY >= (headerTop - 50) - headerHeight)
     {
       current = header;
     }
@@ -71,3 +71,4 @@ window.addEventListener("scroll", () => {
     });
   });
 });
+


### PR DESCRIPTION
Lisää JavaScriptin, joka korostaa sivupalkissa sitä kappaletta/osiota, jonka kohdalle on skrollattu varsinaisessa leipätekstissä.

![js](https://github.com/GispoCoding/master-training-data/assets/118284595/04f07ad9-336a-4121-9f7d-10b863537e5b)

Lisäksi kun sivupalkista klikkaa siirtyäkseen toiseen harjoitukseen, sivupalkki skrollaa automaattisesti oikeaan kohtaan.

Voi kokeilla [täällä testirepossa.](https://gispocoding.github.io/training-master-repo-dev/GE02/index.html#template)

