### PR TITLE
Generate html preview only if latest commit has more than 20 changed lines

### DIFF
--- a/.github/workflows/generate-html-for-pull-request.yaml
+++ b/.github/workflows/generate-html-for-pull-request.yaml
@@ -16,33 +16,53 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
+
+      - name: Check if enough lines were changed
+        id: enough_lines
+        run: |
+          git checkout ${{ github.head_ref }}
+
+          LATEST=$(git rev-parse HEAD)
+          SECOND_LATEST=$(git rev-parse HEAD~1)
+
+          LINES_CHANGED=$(git diff --shortstat $SECOND_LATEST $LATEST | awk '{print $4 + $6}')
+
+          echo "Lines changed: $LINES_CHANGED"
+
+          if [ "$LINES_CHANGED" -gt 20 ]; then
+            echo "continue=true" >> $GITHUB_ENV
+          else
+            echo "continue=false" >> $GITHUB_ENV
+          fi
+
       - name: Find directories with changed rmd or image files
+        if: env.continue == 'true'
         id: changed-files-dir-names
         uses: tj-actions/changed-files@v41
         with:
           files:  |
             src/G*/*.{rmd,Rmd}
             src/G*/img/*.{png,gif}
-            src/G*/img/*/*.{png,gif}            
+            src/G*/img/*/*.{png,gif}
           dir_names: "true"
           dir_names_max_depth: 2
 
 
       - name: Render modified courses to HTML and move output to docs
+        if: env.continue == 'true'
+        env:
+          ARTIFACT: true
+          CHANGED_DIRS: ${{ steps.changed-files-dir-names.outputs.all_changed_files }}
         run: |
-          folder_list="${{ steps.changed-files-dir-names.outputs.all_changed_files }}"
-          IFS=" "
-          read -ra folders <<< "$folder_list"
+          set -e
 
-          export ARTIFACT=true
-
-          for folder in "${folders[@]}"; do
+          for folder in ${CHANGED_DIRS}; do
             code="${folder#src/}"
             ./render.sh $code
           done
-      
+
       - name: Upload artifacts
+        if: env.continue == 'true'
         id: upload-artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -51,6 +71,7 @@ jobs:
           retention-days: 7
 
       - name: Add Comment
+        if: env.continue == 'true'
         uses: actions/github-script@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,4 +83,4 @@ jobs:
               repo: context.repo.repo,
               body: body
             });
-        
+


### PR DESCRIPTION
**Why?**

Previously there could be quite a bit of spam from the GitHub Actions bot, especially if you commit a bunch of one-line suggestions in a PR.

**What?**

The workflow checks that at least 20 lines have been modified and generates the html previews only then.

Resolves: #31 