### PR TITLE
Translate "Next" and "Previous" buttons

### DIFF
--- a/template/js/answer-key.js
+++ b/template/js/answer-key.js
@@ -43,20 +43,40 @@ codeBoxes.forEach(box => {
 
 let show;
 let hide;
+let next;
+let previous;
 
 switch (language) {
   case "EN":
     show = "Show ";
     hide = "Hide ";
+    next = "Next";
+    previous = "Previous";
     break;
   case "SV":
     show = "Visa ";
     hide = "Dölj ";
+    next = "Nästa";
+    previous = "Tillbaka";
     break;
   default:
     show = "Näytä ";
     hide = "Piilota ";
+    next = "Seuraava";
+    previous = "Edellinen";
 }
+
+const navButtons = [...document.getElementsByClassName('btn-default')];
+navButtons.forEach(button => {
+  if (button.textContent === "Next")
+  {
+    button.textContent = next;
+  }
+  else if (button.textContent === "Previous")
+  {
+    button.textContent = previous;
+  }
+});
 
 const answerButtons = [...document.getElementsByClassName('answer_btn')];
 answerButtons.forEach(button => {


### PR DESCRIPTION
Fixes #39 

Note: This is done in the `answer_key.js` although it doesn't really have anything to do with the answer buttons, but since we're already translating different buttons it seemed like the best place to put it.

It would be nice to get the JavaScript stuff cleaned up at some point, it's pretty messy currently.