### PR TITLE
all courses: add links to PDFs

### DIFF
--- a/src/GE01/index.Rmd
+++ b/src/GE01/index.Rmd
@@ -90,3 +90,11 @@ Jos havaitset materiaalissa virheitä, pyydämme ilmoittamaan niistä kouluttaja
 ## Lisenssi ja oikeudet
 
 Nämä materiaalit on "QGIS-lisäosien kehitys" -kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GE01/GE01.pdf)
+:::

--- a/src/GE01_eng/index.Rmd
+++ b/src/GE01_eng/index.Rmd
@@ -89,3 +89,11 @@ If you notice mistakes in these course materials, we ask you to report either di
 
 These materials are developed for the "QGIS plugin development" course by Gispo Finland Ltd.
 The materials are licensed under [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) license.
+
+## Download a PDF version of the material
+
+You can download a PDF version of the material from this link:
+
+::: note-box
+[PDF version of the material](https://github.com/gispocoding/master-training-data/releases/download/GE01_eng/GE01_eng.pdf)
+:::

--- a/src/GP001/index.Rmd
+++ b/src/GP001/index.Rmd
@@ -103,3 +103,11 @@ Jos havaitset materiaalissa virheitä, niin pyydämme ilmoittamaan niistä koulu
 ## Lisenssi ja oikeudet
 
 Nämä materiaalit on "Johdanto paikkatietoon ja QGISin käyttöön"-kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GP001/GP001.pdf)
+:::

--- a/src/GP002/index.Rmd
+++ b/src/GP002/index.Rmd
@@ -112,3 +112,11 @@ License and permissions
 These materials are developed for the Introduction to QGIS course by Gispo Ltd.
 The materials are licensed under [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) license.
 -->
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GP002/GP002.pdf)
+:::

--- a/src/GP002_eng/index.Rmd
+++ b/src/GP002_eng/index.Rmd
@@ -108,3 +108,11 @@ License and permissions
 These materials are developed for the Introduction to QGIS course by Gispo Ltd.
 The materials are licensed under [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) license.
 -->
+
+## Download a PDF version of the material
+
+You can download a PDF version of the material from this link:
+
+::: note-box
+[PDF version of the material](https://github.com/gispocoding/master-training-data/releases/download/GP002_eng/GP002_eng.pdf)
+:::

--- a/src/GP007/index.Rmd
+++ b/src/GP007/index.Rmd
@@ -98,3 +98,11 @@ Jos havaitset materiaalissa virheitä, pyydämme ilmoittamaan niistä kouluttaja
 ## Lisenssi ja oikeudet
 
 Nämä materiaalit on "QGIS perusteet kunnille" -kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GP007/GP007.pdf)
+:::

--- a/src/GS001/index.Rmd
+++ b/src/GS001/index.Rmd
@@ -87,3 +87,11 @@ Jos havaitset materiaalissa virheitä, niin pyydämme ilmoittamaan niistä koulu
 ## Lisenssi ja oikeudet
 
 Nämä materiaalit on "Visualisoinnin mestariksi QGISillä"- kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GS001/GS001.pdf)
+:::

--- a/src/GS002/index.Rmd
+++ b/src/GS002/index.Rmd
@@ -31,6 +31,12 @@ Voit ladata harjoituksissa käytettävän kurssihakemiston tästä linkistä:
 [Kurssihakemisto.zip](https://drive.google.com/file/d/18CBVmGG17ZnPD20f8bsEs3Mn32wQxQQm/view?usp=sharing)
 :::
 
+Ja kurssin harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GS002/GS002.pdf)
+:::
+
 ## Lukuohje
 
 **Web-selaimessa** suoritettavat komennot on merkitty seuraavasti:

--- a/src/GS006/index.Rmd
+++ b/src/GS006/index.Rmd
@@ -91,3 +91,11 @@ Jos havaitset materiaalissa virheitä, niin pyydämme ilmoittamaan niistä koulu
 ## Lisenssi ja oikeudet
 
 Nämä materiaalit on "Johdanto GeoServerin käyttöön" -kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GS006/GS006.pdf)
+:::

--- a/src/GS006_eng/index.Rmd
+++ b/src/GS006_eng/index.Rmd
@@ -92,3 +92,11 @@ If you notice mistakes in these course materials, we ask you to report either di
 
 These materials are developed for the "Introduction to GeoServer" course by Gispo Finland Ltd.
 The materials are licensed under [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) license.
+
+## Download a PDF version of the material
+
+You can download a PDF version of the material from this link:
+
+::: note-box
+[PDF version of the material](https://github.com/gispocoding/master-training-data/releases/download/GS006_eng/GS006_eng.pdf)
+:::

--- a/src/GS008/index.Rmd
+++ b/src/GS008/index.Rmd
@@ -52,3 +52,11 @@ While notes look like this:
 
 These materials are developed for the Advanced GeoServer course by Gispo Ltd.
 The materials are licensed under [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) license.
+
+## Download a PDF version of the material
+
+You can download a PDF version of the material from this link:
+
+::: note-box
+[PDF version of the material](https://github.com/gispocoding/master-training-data/releases/download/GS008/GS008.pdf)
+:::

--- a/src/GS011/index.Rmd
+++ b/src/GS011/index.Rmd
@@ -90,3 +90,11 @@ Jos havaitset materiaalissa virheitä, niin pyydämme ilmoittamaan niistä koulu
 ## Lisenssi ja oikeudet
 
 Nämä materiaalit on "Kartat ja taitot" -kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GS011/GS011.pdf)
+:::

--- a/src/GS014/index.Rmd
+++ b/src/GS014/index.Rmd
@@ -88,3 +88,11 @@ Jos havaitset materiaalissa virheitä, niin pyydämme ilmoittamaan niistä koulu
 ## Lisenssi ja oikeudet
 
 Nämä materiaalit on "Lausekkeet QGISissä" -kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GS014/GS014.pdf)
+:::

--- a/src/GS016/index.Rmd
+++ b/src/GS016/index.Rmd
@@ -112,3 +112,11 @@ Jos havaitset materiaalissa virheitä, niin pyydämme ilmoittamaan niistä koulu
 ## Lisenssi ja oikeudet
 
 Nämä materiaalit on "Paikkatiedon mobiilikeruu QFieldillä" -kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GS016/GS016.pdf)
+:::

--- a/src/GS017/index.Rmd
+++ b/src/GS017/index.Rmd
@@ -102,3 +102,11 @@ Jos havaitset materiaalissa virheitä, niin pyydämme ilmoittamaan niistä koulu
 ## **Lisenssi ja oikeudet**
 
 Nämä materiaalit ovat "Paikkatiedon mobiilikeruu Mergin Mapsilla" -kurssille kehittänyt Gispo Suomi Oy. Materiaalit on lisensoitu seuraavalla lisenssillä: [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)
+
+## Materiaali PDF-muodossa
+
+Voit ladata harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/GS017/GS017.pdf)
+:::


### PR DESCRIPTION
This adds PDF links to the materials.

The links are included to `index.Rmd` for each course, with the exception of tailored courses (these are untouched).

Some index pages already had a section on downloading course materials. For these cases, the PDF link is included in this section. Otherwise it is in its own section at the bottom of the index page.

**Note** that at the moment some PDF links are most likely dead. For many courses the PDFs are still unbuilt, so the links will become live when the changes are on main branch and the PDFs get built / released.