### PR TITLE
add pdf links to template

### DIFF
--- a/template/index_en.Rmd
+++ b/template/index_en.Rmd
@@ -27,6 +27,13 @@ You can download the data used in the exercises from this link:
 [course_directory.zip](data_package_link_replace)
 :::
 
+and the exercises in PDF format from this link:
+
+::: note-box
+[Exercises in PDF format](https://github.com/gispocoding/master-training-data/releases/download/course_code_replace/course_code_replace.pdf)
+:::
+
+
 ## Reading Guide
 
 Commands to execute in a **web browser** are displayed as follows:

--- a/template/index_fi.Rmd
+++ b/template/index_fi.Rmd
@@ -27,6 +27,12 @@ Voit ladata harjoituksissa käytettävän kurssihakemiston tästä linkistä:
 [Kurssihakemisto.zip](data_package_link_replace)
 :::
 
+ja kurssin harjoitukset PDF-muodossa tästä linkistä:
+
+::: note-box
+[Harjoitukset PDF-muodossa](https://github.com/gispocoding/master-training-data/releases/download/course_code_replace/course_code_replace.pdf)
+:::
+
 ## Lukuohje
 
 **Web-selaimessa** suoritettavat komennot on merkitty seuraavasti:

--- a/template/index_sv.Rmd
+++ b/template/index_sv.Rmd
@@ -27,6 +27,13 @@ Voit ladata harjoituksissa käytettävän kurssihakemiston tästä linkistä:
 [Kurskatalog.zip](data_package_link_replace)
 :::
 
+och kursens övningar i PDF-format:
+
+::: note-box
+[Övningar i PDF-format](https://github.com/gispocoding/master-training-data/releases/download/course_code_replace/course_code_replace.pdf)
+:::
+
+
 ## Läshjälp
 
 **Web-selaimessa** suoritettavat komennot on merkitty seuraavasti:


### PR DESCRIPTION
A bit of a continuation to #75.

This adds the PDF links to the template index.rmds as well - We probably want to link to the PDF by default since it gets built anyways.